### PR TITLE
Add check for NODE_ENV to be development when emitting warnings

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -217,7 +217,7 @@ class State extends EventEmitter {
 		if (config.validator) {
 			var validatorReturn = this.callFunction_(config.validator, [value, name, this]);
 
-			if (validatorReturn instanceof Error) {
+			if (process.env.NODE_ENV === 'developement' && validatorReturn instanceof Error) {
 				console.error(`Warning: ${validatorReturn}`);
 			}
 			return validatorReturn;


### PR DESCRIPTION
React takes the approach of warning for everything besides production, I think it may be better to only emit warnings for a specific 'development' environment. Let me know what you think. Im sure this may change as well if API changes.
